### PR TITLE
ResultStoreTable clean up in AsyncCleanerService carbon-190

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
@@ -31,7 +31,7 @@ public class AsyncCleanerService {
 
     @Inject
     private AsyncCleanerService(Elide elide, Integer maxRunTimeMinutes, Integer queryCleanupDays,
-            AsyncQueryDAO asyncQueryDao) {
+            AsyncQueryDAO asyncQueryDao, ResultStorageEngine resultStorageEngine) {
 
         //If query is still running for twice than maxRunTime, then interrupt did not work due to host/app crash.
         int queryRunTimeThresholdMinutes = maxRunTimeMinutes * 2;
@@ -39,7 +39,7 @@ public class AsyncCleanerService {
         // Setting up query cleaner that marks long running query as TIMEDOUT.
         ScheduledExecutorService cleaner = Executors.newSingleThreadScheduledExecutor();
         AsyncQueryCleanerThread cleanUpTask = new AsyncQueryCleanerThread(queryRunTimeThresholdMinutes, elide,
-            queryCleanupDays, asyncQueryDao);
+            queryCleanupDays, asyncQueryDao, resultStorageEngine);
 
         // Since there will be multiple hosts running the elide service,
         // setting up random delays to avoid all of them trying to cleanup at the same time.
@@ -63,9 +63,10 @@ public class AsyncCleanerService {
      * @param asyncQueryDao DAO Object
      */
     public static void init(Elide elide, Integer maxRunTimeMinutes, Integer queryCleanupDays,
-            AsyncQueryDAO asyncQueryDao) {
+            AsyncQueryDAO asyncQueryDao, ResultStorageEngine resultStorageEngine) {
         if (asyncCleanerService == null) {
-            asyncCleanerService = new AsyncCleanerService(elide, maxRunTimeMinutes, queryCleanupDays, asyncQueryDao);
+            asyncCleanerService = new AsyncCleanerService(elide, maxRunTimeMinutes, queryCleanupDays, asyncQueryDao,
+                    resultStorageEngine);
         } else {
             log.debug("asyncCleanerService is already initialized.");
         }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCleanerThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCleanerThread.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.async.service;
 
 import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.QueryStatus;
 
 import lombok.AllArgsConstructor;
@@ -15,7 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
+import java.util.Iterator;
 
 /**
  * Runnable thread for updating AsyncQueryThread status.
@@ -31,6 +34,7 @@ public class AsyncQueryCleanerThread implements Runnable {
     private Elide elide;
     private int queryCleanupDays;
     private AsyncQueryDAO asyncQueryDao;
+    private ResultStorageEngine resultStorageEngine;
 
     @Override
     public void run() {
@@ -48,7 +52,13 @@ public class AsyncQueryCleanerThread implements Runnable {
 
         String filterExpression = "createdOn=le='" + cleanupDateFormatted + "'";
 
-        asyncQueryDao.deleteAsyncQueryAndResultCollection(filterExpression);
+        Collection<AsyncQuery> asyncQueryList = asyncQueryDao.deleteAsyncQueryAndResultCollection(filterExpression);
+        Iterator itr = asyncQueryList.iterator();
+
+        while (itr.hasNext()) {
+            AsyncQuery query = (AsyncQuery) itr.next();
+            resultStorageEngine.deleteResultsByID(query.getId());
+        }
 
     }
 

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncCleanerServiceTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncCleanerServiceTest.java
@@ -24,7 +24,8 @@ public class AsyncCleanerServiceTest {
         Elide elide = mock(Elide.class);
 
         AsyncQueryDAO dao = mock(DefaultAsyncQueryDAO.class);
-        AsyncCleanerService.init(elide, 5, 60, dao);
+        ResultStorageEngine resultStorageEngine = mock(DefaultResultStorageEngine.class);
+        AsyncCleanerService.init(elide, 5, 60, dao, resultStorageEngine);
         service = AsyncCleanerService.getInstance();
     }
 

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryCleanerThreadTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryCleanerThreadTest.java
@@ -32,6 +32,7 @@ public class AsyncQueryCleanerThreadTest {
     private AsyncQueryCleanerThread cleanerThread;
     private Elide elide;
     private AsyncQueryDAO asyncQueryDao;
+    private ResultStorageEngine resultStorageEngine;
 
     @BeforeEach
     public void setupMocks() {
@@ -45,7 +46,9 @@ public class AsyncQueryCleanerThreadTest {
                         .build());
 
         asyncQueryDao = mock(DefaultAsyncQueryDAO.class);
-        cleanerThread = new AsyncQueryCleanerThread(7, elide, 7, asyncQueryDao);
+        resultStorageEngine = mock(DefaultResultStorageEngine.class);
+        cleanerThread = new AsyncQueryCleanerThread(7, elide, 7, asyncQueryDao,
+                resultStorageEngine);
     }
 
     @Test

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
@@ -108,7 +108,7 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
                 dictionary.bindTrigger(Invoice.class, "complete", CREATE, PRECOMMIT, invoiceCompletionHook);
                 dictionary.bindTrigger(Invoice.class, "complete", UPDATE, PRECOMMIT, invoiceCompletionHook);
 
-                AsyncCleanerService.init(elide, 60, 5, asyncQueryDao);
+                AsyncCleanerService.init(elide, 60, 5, asyncQueryDao, resultStorageEngine);
                 bind(AsyncCleanerService.getInstance()).to(AsyncCleanerService.class);
             }
         });

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
@@ -78,9 +78,9 @@ public class ElideAsyncConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnProperty(prefix = "elide.async", name = "cleanupEnabled", matchIfMissing = false)
     public AsyncCleanerService buildAsyncCleanerService(Elide elide, ElideConfigProperties settings,
-            AsyncQueryDAO asyncQueryDao) {
+            AsyncQueryDAO asyncQueryDao, ResultStorageEngine resultStorageEngine) {
         AsyncCleanerService.init(elide, settings.getAsync().getMaxRunTimeMinutes(),
-                settings.getAsync().getQueryCleanupDays(), asyncQueryDao);
+                settings.getAsync().getQueryCleanupDays(), asyncQueryDao, resultStorageEngine);
         return AsyncCleanerService.getInstance();
     }
 

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -134,7 +134,7 @@ public class ElideResourceConfig extends ResourceConfig {
                         resultStorageEngine = new DefaultResultStorageEngine(asyncElide, asyncElide.getDataStore(),
                                 settings.getBaseURL());
                     }
-                    bind(asyncQueryDao).to(AsyncQueryDAO.class);
+                    bind(resultStorageEngine).to(ResultStorageEngine.class);
 
                     AsyncExecutorService.init(elide, settings.getAsyncThreadSize(),
                             settings.getAsyncMaxRunTimeMinutes(), asyncQueryDao, resultStorageEngine);
@@ -152,7 +152,7 @@ public class ElideResourceConfig extends ResourceConfig {
                     // Binding async cleanup service
                     if (settings.enableAsyncCleanup()) {
                         AsyncCleanerService.init(elide, settings.getAsyncMaxRunTimeMinutes(),
-                                settings.getAsyncQueryCleanupDays(), asyncQueryDao);
+                                settings.getAsyncQueryCleanupDays(), asyncQueryDao, resultStorageEngine);
                         bind(AsyncCleanerService.getInstance()).to(AsyncCleanerService.class);
                     }
                 }


### PR DESCRIPTION
Resolves#1272

## Description
i) Update the AsyncCleanerService to clean up the results in the ResultStoreTable when the Async Table is cleaned up.

## Motivation and Context
whenever the queries are removed or cleaned from the AsyncQuery table the corresponding queries on the ResultStorageEngine are also removed.

## How Has This Been Tested?
Tests in the AsyncCleanerServiceTest and AsyncQueryCleanerThreadTest have been modified and run.

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
