### PR TITLE
Data export Download Controller

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -181,6 +181,7 @@ public class AsyncQueryThread implements Callable<AsyncQueryResult> {
             json2csv = flatMe.json2Sheet().headerSeparator("_").getJsonAsSheet();
             for (Object[] obj : json2csv) {
                 str.append(Arrays.toString(obj));
+                str.append(System.getProperty("line.separator"));
             }
         } catch (Exception e) {
             log.debug("Exception while converting to CSV: {}", e.getMessage());

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/DownloadController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/DownloadController.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.spring.controllers;
+
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.ResultFormatType;
+import com.yahoo.elide.async.service.ResultStorageEngine;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Blob;
+import java.sql.SQLException;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.rowset.serial.SerialBlob;
+
+@Slf4j
+@Configuration
+@RestController
+public class DownloadController {
+
+    private ResultStorageEngine resultStorageEngine;
+    private AsyncQuery asyncQuery;
+
+    @Autowired
+    public DownloadController(ResultStorageEngine resultStorageEngine, AsyncQuery asyncQuery) {
+        log.debug("Started ~~");
+        this.resultStorageEngine = resultStorageEngine;
+        this.asyncQuery = asyncQuery;
+
+    }
+
+    @GetMapping("/download/file")
+    public void download(HttpServletResponse response) throws SQLException, IOException {
+
+        ///************* Getresults from ResultStorageEngine
+        byte[] temp = resultStorageEngine.getResultsByID(asyncQuery.getId());
+        Blob blob = new SerialBlob(temp);
+        String reconstructedStr = new String(blob.getBytes((long) 1, (int) blob.length()));
+        PrintWriter writer = response.getWriter();
+
+        if (asyncQuery.getResultFormatType() == ResultFormatType.CSV) {
+            response.setContentType("text/csv");
+            response.setHeader("Content-Disposition", "attachment; file=file.csv");
+
+            ///************* Writing to the writer
+            String[] arrOfStr = reconstructedStr.split("\n");
+
+            for (int i = 0; i < arrOfStr.length; i++) {
+                String s1 = arrOfStr[i];
+                String s2 = s1.substring(1, s1.length() - 1) + "\n";
+                writer.write(s2);
+            }
+        } else if (asyncQuery.getResultFormatType() == ResultFormatType.JSON) {
+            response.setContentType("application/json");
+            response.setHeader("Content-Disposition", "attachment; file=file.json");
+            writer.write(reconstructedStr);
+        }
+
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
@@ -12,6 +12,9 @@ elide:
   swagger:
     path: /doc
     enabled: true
+  download:
+    path: /download
+    enabled: true
   async:
     enabled: true
     threadPoolSize: 7


### PR DESCRIPTION
Resolves #1272

## Description
i) In elide-async, a new controller will be added with 1 get endpoint for download by Id (/asyncQueryResultStore/{id}). We can use elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java for reference.
ii) In the controller logic, we will query the AsyncQuery Table to get the expected format. We will use returned value to set the response header type to "JSON/CSV/". Content Disposition will be set to "Attachment" in the header. Retrieve the results from the ResultStore table using ResultStorageEngine method and send it back in the response.
iii) In elide-standalone, similar to json, swagger and graphqql, we will have a new Servlet, enabled only in case of dynamic config.
iv) In elide-spring, similar to json, swagger and graphqql, we will have a new controller, enabled only in case of dynamic config.

## Motivation and Context
This change is required to enable the download of the query results

## How Has This Been Tested?
Currently tested using spring boor example

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
